### PR TITLE
Rearranged and tweaked test definintions

### DIFF
--- a/usng4j-impl/src/test/java/org/codice/usng4j/impl/UtmUpsCoordinateImplTest.java
+++ b/usng4j-impl/src/test/java/org/codice/usng4j/impl/UtmUpsCoordinateImplTest.java
@@ -6,43 +6,20 @@ import org.junit.Test;
 
 public class UtmUpsCoordinateImplTest {
 
+  // UTM parsing tests
+
   @Test
-  public void testParsingValidUtmStringAsUtm() {
+  public void testParsingUtmAsUtm() {
     fail();
   }
 
   @Test
-  public void testParsingInvalidUtmStringAsUtm() {
+  public void testParsingInvalidUtm() {
     fail();
   }
 
   @Test
-  public void testParsingValidUtmStringAsUtmUps() {
-    fail();
-  }
-
-  @Test
-  public void testParsingInvalidUtmStringAsUtmUps() {
-    fail();
-  }
-
-  @Test
-  public void testParsingValidUpsStringAsUps() {
-    fail();
-  }
-
-  @Test
-  public void testParsingInvalidUpsStringAsUps() {
-    fail();
-  }
-
-  @Test
-  public void testParsingValidUpsStringAsUtmUps() {
-    fail();
-  }
-
-  @Test
-  public void testParsingInvalidUpsStringAsUtmUps() {
+  public void testParsingUpsAsUtm() {
     fail();
   }
 
@@ -51,13 +28,47 @@ public class UtmUpsCoordinateImplTest {
     fail();
   }
 
+  // UPS parsing tests
+
   @Test
-  public void testParsingUtmOverlappingUpsAsUtmUps() {
+  public void testParsingUpsAsUps() {
+    fail();
+  }
+
+  @Test
+  public void testParsingInvalidUps() {
+    fail();
+  }
+
+  @Test
+  public void testParsingUtmAsUps() {
     fail();
   }
 
   @Test
   public void testParsingUpsOverlappingUtmAsUps() {
+    fail();
+  }
+
+  // UTM/UPS parsing tests
+
+  @Test
+  public void testParsingUtmAsUtmUps() {
+    fail();
+  }
+
+  @Test
+  public void testParsingUpsAsUtmUps() {
+    fail();
+  }
+
+  @Test
+  public void testParsingInvalidUtmUps() {
+    fail();
+  }
+
+  @Test
+  public void testParsingUtmOverlappingUpsAsUtmUps() {
     fail();
   }
 


### PR DESCRIPTION
I rearranged the test methods to group them and make the test case enumeration patterns easier to see. I grouped them by UTM, UPS, and UTM/UPS and arranged the tests within those groups as valid cases, then invalid cases, then overlapping cases.

I also removed some terms in test method names that seemed to be unnecessary; the logic is described below:
- Specifying that a UTM string is "valid" is redundant; if the string is not valid, then it is not UTM at all.
- Specifying that we are parsing strings seems unnecessary; parsing of coordinates will certainly take place on some form of text and all parsing methods that we plan to implement take strings only, so there is nothing to differentiate it from.
- Tests with specifications like "testParsingInvalidUtmAsUtm" can be simplified to "testParsingInvalidUtm"; as stated before, invalid UTM is not truly UTM at all, so saying that you're parsing invalid UTM can only imply that you're parsing it as UTM, making "AsUtm" redundant.